### PR TITLE
chore(ci): disable verbose on release PR creation

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,6 +27,5 @@ jobs:
     - uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11  # v0.5.128
       with:
         command: release-pr
-        verbose: true
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Turns out the issue was that the branch release-plz was trying to push / create was under the branch protection ruleset, so it was (rightfully) told no.

Excluding release-plz's branch pattern from the ruleset fixes the issue. Not sure there's a better way, I was not able to find a user to whitelist (grant bypass access to).